### PR TITLE
Add OSX compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 *~
 __pycache__
 *.h5
+
+# For clion IDE
+.idea
+
+# For cmake
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 This repo is currently a sandbox for personal experimentation in neural net training in Go. I haven't made any particular attempt to make the training pipeline usable by others, but if you're interested, the rough summary is:
 
    * You must have HDF5 installed for C++ (https://support.hdfgroup.org/HDF5/release/obtainsrc.html), as well as Tensorflow installed for Python 3.
-   * Compile using "compile.sh" in writedata, which expects you to have h5c++ available. (yes, no makefiles or build system, very hacky).
+   * Compile using CMake and make in writedata, which expects you to have h5c++
+     available. (on windows you can also use the deprecated compile.sh):
+      * `cd writedata`
+      * `cmake .`
+      * `make`
    * Run the resulting "write.exe" with appropriate flags on a directory of SGF files to generate an h5 file of preprocessed training data.
    * Run train.py using that h5 file to train the neural net.
 

--- a/writedata/CMakeLists.txt
+++ b/writedata/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.10)
+project(writedata)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(.)
+include_directories(core)
+include_directories(tclap-1.2.1)
+include_directories(tclap-1.2.1/include)
+include_directories(tclap-1.2.1/include/tclap)
+
+add_executable(write
+        core/config.h
+        core/global.cpp
+        core/global.h
+        core/hash.cpp
+        core/hash.h
+        core/md5.cpp
+        core/md5.h
+        core/multithread.h
+        core/rand.cpp
+        core/rand.h
+        core/rand_helpers.h
+        core/sha2.cpp
+        core/sha2.h
+        core/timer.cpp
+        core/timer.h
+        tclap-1.2.1/include/tclap/Arg.h
+        tclap-1.2.1/include/tclap/ArgException.h
+        tclap-1.2.1/include/tclap/ArgTraits.h
+        tclap-1.2.1/include/tclap/CmdLine.h
+        tclap-1.2.1/include/tclap/CmdLineInterface.h
+        tclap-1.2.1/include/tclap/CmdLineOutput.h
+        tclap-1.2.1/include/tclap/Constraint.h
+        tclap-1.2.1/include/tclap/DocBookOutput.h
+        tclap-1.2.1/include/tclap/HelpVisitor.h
+        tclap-1.2.1/include/tclap/IgnoreRestVisitor.h
+        tclap-1.2.1/include/tclap/MultiArg.h
+        tclap-1.2.1/include/tclap/MultiSwitchArg.h
+        tclap-1.2.1/include/tclap/OptionalUnlabeledTracker.h
+        tclap-1.2.1/include/tclap/StandardTraits.h
+        tclap-1.2.1/include/tclap/StdOutput.h
+        tclap-1.2.1/include/tclap/SwitchArg.h
+        tclap-1.2.1/include/tclap/UnlabeledMultiArg.h
+        tclap-1.2.1/include/tclap/UnlabeledValueArg.h
+        tclap-1.2.1/include/tclap/ValueArg.h
+        tclap-1.2.1/include/tclap/ValuesConstraint.h
+        tclap-1.2.1/include/tclap/VersionVisitor.h
+        tclap-1.2.1/include/tclap/Visitor.h
+        tclap-1.2.1/include/tclap/XorHandler.h
+        tclap-1.2.1/include/tclap/ZshCompletionOutput.h
+        datapool.cpp
+        datapool.h
+        fastboard.cpp
+        fastboard.h
+        sgf.cpp
+        sgf.h
+        write.cpp)
+
+find_package(HDF5 REQUIRED COMPONENTS C CXX)
+
+if (HDF5_FOUND)
+    include_directories(${HDF5_INCLUDE_DIRS})
+    target_link_libraries (write ${HDF5_LIBRARIES})
+endif (HDF5_FOUND)

--- a/writedata/core/timer.cpp
+++ b/writedata/core/timer.cpp
@@ -7,8 +7,8 @@
  #define _IS_WINDOWS
 #elif _WIN64
  #define _IS_WINDOWS
-#elif __unix
- #define _IS_UNIX
+#elif __unix || __APPLE__
+  #define _IS_UNIX
 #else
  #error Unknown OS!
 #endif


### PR DESCRIPTION
Closes #2 

# What

I used `__APPLE__` macro to detect OSX as Unix
[docs](https://developer.apple.com/library/content/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html#//apple_ref/doc/uid/TP40002850-SW13)

I created a CMake file as the build comment in the readme worked but the generated binary segfaulted.

# Proof it works

![image](https://user-images.githubusercontent.com/13785185/39097110-1883a086-4658-11e8-986e-d7d218d4a3f6.png)

